### PR TITLE
Add the get_absolute_url func to the Youtuber and YoutuberSerializer models

### DIFF
--- a/youtube_base/youtubers/models.py
+++ b/youtube_base/youtubers/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.urls import reverse
 
 
 class Youtuber(models.Model):
@@ -43,6 +44,9 @@ class Youtuber(models.Model):
     class Meta:
         verbose_name_plural = "Youtubers"
         ordering = ['id']
+
+    def get_absolute_url(self):
+        return reverse('youtuber_detail', args=[str(self.slug_name)])
 
 
 class Video(models.Model):

--- a/youtube_base/youtubers/serialaizer.py
+++ b/youtube_base/youtubers/serialaizer.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from .models import Youtuber
 
 
@@ -16,7 +17,14 @@ class YoutuberSerializer(serializers.ModelSerializer):
     Attributes:
         model (Model): The model the serializer is tied to, in this case, the Youtuber model.
         fields (str): The fields from the model to be serialized. '__all__' to include all fields.
+
     """
+    absolute_url = serializers.SerializerMethodField()
+
     class Meta:
         model = Youtuber
         fields = '__all__'
+
+    def get_absolute_url(self, obj):
+        print(obj.get_absolute_url, 'qaqwsdqwdewdfewf')
+        return obj.get_absolute_url()

--- a/youtube_base/youtubers/templates/youtubers/youtuber_list.html
+++ b/youtube_base/youtubers/templates/youtubers/youtuber_list.html
@@ -10,7 +10,7 @@
                 <div class="col-md-4">
                     <div class="card mb-4">
                         <div class="card-body">
-                            <h5 class="card-title"><a href="{% url 'youtuber_detail' youtuber.slug_name %}">{{ youtuber.channel_title }}</a></h5>
+                            <h5 class="card-title"><a href="{{ youtuber.absolute_url }}">{{ youtuber.channel_title }}</a></h5>
                             <p class="card-text">{{ youtuber.channel_description }}</p>
                             <a href="{{ youtuber.youtube_url }}" class="btn btn-primary">Go to channel</a>
                         </div>

--- a/youtube_base/youtubers/urls.py
+++ b/youtube_base/youtubers/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path('add_youtuber/', AddYoutuberView.as_view(), name='add_youtuber'),
     path('category_list/', views.CategoryList.as_view(), name='category_list'),
     path('youtuber_list/', views.YoutuberList.as_view(), name='youtuber_list'),
-    path('youtuber_list/<slug:slug>/',
+    path('youtuber_list/<slug:slug_name>/',
          views.YoutuberDetailView.as_view(),
          name='youtuber_detail'),
 ]

--- a/youtube_base/youtubers/views.py
+++ b/youtube_base/youtubers/views.py
@@ -7,11 +7,11 @@ from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.edit import FormView
 
 from youtube_api.add_youtuber import YoutubeApi
-from .serialaizer import YoutuberSerializer
 
 from . import models
 from .forms import AddYoutuberForm, CategoryForm
 from .models import Category, Youtuber
+from .serialaizer import YoutuberSerializer
 
 
 class TestTemplateView(TemplateView):
@@ -187,6 +187,7 @@ class YoutuberDetailView(DetailView):
     """
     model = Youtuber
     slug_field = 'slug_name'
+    slug_url_kwarg = 'slug_name'
     template_name = 'youtubers/youtuber_detail.html'
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Function get_absolute_url must be added to the serializer class because after serialization the object loses default Django functions.